### PR TITLE
tintColor for iOS 13 change

### DIFF
--- a/DTPagerController/Classes/DTSegmentedControl.swift
+++ b/DTPagerController/Classes/DTSegmentedControl.swift
@@ -45,7 +45,7 @@ open class DTSegmentedControl: UISegmentedControl, DTSegmentedControlProtocol {
         setDividerImage(UIImage(), forLeftSegmentState: UIControl.State.selected, rightSegmentState: UIControl.State(), barMetrics: UIBarMetrics.default)
     }
     
-    func setTintColor(_ color: UIColor) {
+    private func setTintColor(_ color: UIColor) {
         if #available(iOS 13.0, *) {
             selectedSegmentTintColor = color
         } else {

--- a/DTPagerController/Classes/DTSegmentedControl.swift
+++ b/DTPagerController/Classes/DTSegmentedControl.swift
@@ -40,9 +40,16 @@ open class DTSegmentedControl: UISegmentedControl, DTSegmentedControlProtocol {
     }
 
     func commonInit() {
-        tintColor = UIColor.clear
+        setTintColor(.clear)
         setDividerImage(UIImage(), forLeftSegmentState: UIControl.State(), rightSegmentState: UIControl.State.selected, barMetrics: UIBarMetrics.default)
         setDividerImage(UIImage(), forLeftSegmentState: UIControl.State.selected, rightSegmentState: UIControl.State(), barMetrics: UIBarMetrics.default)
     }
-
+    
+    func setTintColor(_ color: UIColor) {
+        if #available(iOS 13.0, *) {
+            selectedSegmentTintColor = color
+        } else {
+            tintColor = color
+        }
+    }
 }


### PR DESCRIPTION
iOS 13 tintColor no longer works. 
Added  selectedSegmentTintColor to handle this case.