### PR TITLE
fix: SwiftPM now working

### DIFF
--- a/DTPagerController/Classes/UIViewController.swift
+++ b/DTPagerController/Classes/UIViewController.swift
@@ -5,7 +5,7 @@
 //  Created by tungvoduc on 25/02/2018.
 //
 
-import Foundation
+import UIKit
 
 public extension UIViewController {
     var pagerController: DTPagerController? {


### PR DESCRIPTION
When adding this project as dependency with Swift PM UIKit was not defined. This error occurred because, as I see, you were importing UIKit only in Pods header files and this not working with Swift PM.